### PR TITLE
Fix issue 42

### DIFF
--- a/Run-ExchangeAnalyzer.ps1
+++ b/Run-ExchangeAnalyzer.ps1
@@ -159,7 +159,7 @@ try
     Write-Verbose "$($ExchangeDatabases.Count) databases found."
 
     Write-Progress -Activity $ProgressActivity -Status "Get-DatabaseAvailabilityGroup" -PercentComplete 4
-    $ExchangeDAGs = @(Get-DatabaseAvailabilityGroup -Status -ErrorAction STOP)
+    $ExchangeDAGs = @(Get-DatabaseAvailabilityGroup -ErrorAction STOP)
     Write-Verbose "$($ExchangeDAGs.Count) DAGs found."
 }
 catch

--- a/Run-ExchangeAnalyzer.ps1
+++ b/Run-ExchangeAnalyzer.ps1
@@ -158,6 +158,8 @@ try
     $ExchangeDatabases = @(Get-MailboxDatabase -Status -ErrorAction STOP)
     Write-Verbose "$($ExchangeDatabases.Count) databases found."
 
+    #Do not use -Status switch here as it causes an error to be thrown. DAG status should be
+    #queried later after filtering DAG list to only v15.x DAGs.
     Write-Progress -Activity $ProgressActivity -Status "Get-DatabaseAvailabilityGroup" -PercentComplete 4
     $ExchangeDAGs = @(Get-DatabaseAvailabilityGroup -ErrorAction STOP)
     Write-Verbose "$($ExchangeDAGs.Count) DAGs found."


### PR DESCRIPTION
Fix for error being thrown when Get-DatabaseAvailabilityGroup is used with -Status switch when an Exchange 2010 DAG with at least 1 member exists in the organization.