### PR TITLE
Added POP001 test - Status of POP3 services

### DIFF
--- a/Data/Tests.xml
+++ b/Data/Tests.xml
@@ -77,4 +77,15 @@
 		<IfWarningComments></IfWarningComments>
 		<IfFailedComments>The Active Directory forest does not meet the required functional level.</IfFailedComments>
 	</Test>
+    
+    <Test>
+		<Id>POP001</Id>
+		<Category>POP</Category>
+		<Name>POP Service Status</Name>
+		<Description>Check the status of the POP services.</Description>
+		<IfInfoComments></IfInfoComments>
+		<IfPassedComments></IfPassedComments>
+		<IfWarningComments></IfWarningComments>
+		<IfFailedComments></IfFailedComments>
+	</Test>
 </Tests>

--- a/Tests/POP001.ps1
+++ b/Tests/POP001.ps1
@@ -1,0 +1,57 @@
+#This is your test
+Function Run-POP001()
+{
+    [CmdletBinding()]
+    param()
+
+    $TestID = "POP001"
+    Write-Verbose "----- Starting test $TestID"
+
+    $PassedList = @()
+    $FailedList = @()
+    $WarningList = @()
+    $InfoList = @()
+    $ErrorList = @()
+
+    $POPServers = @($ExchangeServers | Where {$_.IsClientAccessServer -or $_.IsMailboxServer})
+
+    foreach ($Server in $POPServers)
+    {
+        Write-Verbose "Checking POP services for $($Server)"
+
+        try
+        {
+            #This test won't return StartupType. Need to replace with a WMI query once the WMI framework
+            #has been built into the ExchangeAnalyzer module.
+            $PopServices = @(Get-Service -ComputerName $Server MSExchangePOP* -ErrorAction STOP)
+            foreach ($PopService in $PopServices)
+            {
+                $tmpString = "$($Server): $($PopService.DisplayName) is $($PopService.Status)"
+                Write-Verbose $tmpString
+                $InfoList += $tmpString
+            }
+        }
+        catch
+        {
+            Write-Verbose "Unable to determine POP service status"
+            Write-Verbose $_.Exception.Message
+
+            $ErrorList += "$($Server) - unable to determine POP service status."
+        }
+    }
+
+    #Roll the object to be returned to the results
+    $ReportObj = Get-TestResultObject -ExchangeAnalyzerTests $ExchangeAnalyzerTests `
+                                      -TestId $TestID `
+                                      -PassedList $PassedList `
+                                      -FailedList $FailedList `
+                                      -WarningList $WarningList `
+                                      -InfoList $InfoList `
+                                      -ErrorList $ErrorList `
+                                      -Verbose:($PSBoundParameters['Verbose'] -eq $true)
+
+    return $ReportObj
+}
+
+Run-POP001
+


### PR DESCRIPTION
This is a simple, informational test to determine the state of the POP3 services. The test uses Get-Service as an interim solution, which can read the state of the service but not the startup mode, while development continues on more robust helper functions for WMI/CIM (Win32_Service will be able to report the startup mode as well).