### PR TITLE
POP002 - POP Secure Login Test

### DIFF
--- a/Data/Tests.xml
+++ b/Data/Tests.xml
@@ -46,6 +46,17 @@
 	</Test>
 
 	<Test>
+		<Id>POP002</Id>
+		<Category>POP</Category>
+		<Name>POP Secure Login</Name>
+		<Description>Check that insecure POP logins are not permitted.</Description>
+		<IfInfoComments></IfInfoComments>
+		<IfPassedComments>No POP services allow insecure logins.</IfPassedComments>
+		<IfWarningComments>One or more POP services may allow insecure logins.</IfWarningComments>
+		<IfFailedComments>One or more POP services allows insecure login.</IfFailedComments>
+	</Test>
+
+	<Test>
 		<Id>DB001</Id>
 		<Category>Databases</Category>
 		<Name>Database Backups</Name>

--- a/Run-ExchangeAnalyzer.ps1
+++ b/Run-ExchangeAnalyzer.ps1
@@ -256,6 +256,11 @@ Write-Verbose $msgString
 $CASURLs = @(Get-ExchangeURLs $ClientAccessServers -Verbose:($PSBoundParameters['Verbose'] -eq $true))
 Write-Verbose "CAS URLs collected from $($CASURLs.Count) servers."
 
+#Get all POP settings for CAS/MBX servers
+$msgString = "Collecting POP settings from Client Access and Mailbox servers"
+Write-Progress -Activity $ProgressActivity -Status $msgString -PercentComplete 10
+Write-Verbose $msgString
+$AllPOPSettings = @($ExchangeServers | Get-PopSettings)
 
 #endregion -Basic Data Collection
 

--- a/Tests/POP002.ps1
+++ b/Tests/POP002.ps1
@@ -1,0 +1,61 @@
+#This is your test
+Function Run-POP002()
+{
+    [CmdletBinding()]
+    param()
+
+    $TestID = "POP002"
+    Write-Verbose "----- Starting test $TestID"
+
+    $PassedList = @()
+    $FailedList = @()
+    $WarningList = @()
+    $InfoList = @()
+    $ErrorList = @()
+
+    #Check POP settings for SecureLogin
+
+    foreach ($PopSetting in $AllPopSettings)
+    {
+        Write-Verbose "Checking POP settings for $($PopSetting.Server)"
+        
+        if ($PopSetting.LoginType -ieq "SecureLogin")
+        {
+            Write-Verbose "$($PopSetting) requires secure login"
+            $PassedList += $PopSetting.Server
+        }
+        else
+        {
+            #SecureLogin is not enabled, but server is secure if no port binding exists for
+            #unencrypted connections, therefore forcing connections on the SSL port only
+            
+            if ($PopSetting.UnencryptedOrTLSBindings.Count -gt 0)
+            {
+                $tmpString = "$($PopSetting.Server) allows plain text login over insecure ports"
+                Write-Verbose $tmpString
+                $FailedList += $tmpString
+            }
+            else
+            {
+                $tmpString = "$($PopSetting.Server) allows plain text login, but has no insecure port bindings"
+                Write-Verbose $tmpString
+                $WarningList += $tmpString
+            }
+        }
+    }
+
+    #Roll the object to be returned to the results
+    $ReportObj = Get-TestResultObject -ExchangeAnalyzerTests $ExchangeAnalyzerTests `
+                                      -TestId $TestID `
+                                      -PassedList $PassedList `
+                                      -FailedList $FailedList `
+                                      -WarningList $WarningList `
+                                      -InfoList $InfoList `
+                                      -ErrorList $ErrorList `
+                                      -Verbose:($PSBoundParameters['Verbose'] -eq $true)
+
+    return $ReportObj
+}
+
+Run-POP002
+


### PR DESCRIPTION
This test looks for SecureLogin as the LoginType for POP services.

If SecureLogin is configured, the server passes the test.

If another login type (either of the PlainText* options) is configured, but insecure port bindings have been removed, the server has a warning result.

If another login type (either of the PlainText* options) is configured, and insecure port bindings exist, the server fails.