### PR TITLE
POP003 - Check POP protocol logging

### DIFF
--- a/Data/Tests.xml
+++ b/Data/Tests.xml
@@ -68,6 +68,17 @@
 	</Test>
 
 	<Test>
+		<Id>POP003</Id>
+		<Category>POP</Category>
+		<Name>POP Protocol Logging</Name>
+		<Description>Check that protocol logging is not enabled for POP.</Description>
+		<IfInfoComments></IfInfoComments>
+		<IfPassedComments>No POP services have protocol logging enabled.</IfPassedComments>
+		<IfWarningComments>One or more POP services has protocol logging enabled.</IfWarningComments>
+		<IfFailedComments></IfFailedComments>
+	</Test>
+
+	<Test>
 		<Id>DB001</Id>
 		<Category>Databases</Category>
 		<Name>Database Backups</Name>

--- a/Run-ExchangeAnalyzer.ps1
+++ b/Run-ExchangeAnalyzer.ps1
@@ -260,7 +260,8 @@ Write-Verbose "CAS URLs collected from $($CASURLs.Count) servers."
 $msgString = "Collecting POP settings from Client Access and Mailbox servers"
 Write-Progress -Activity $ProgressActivity -Status $msgString -PercentComplete 10
 Write-Verbose $msgString
-$AllPOPSettings = @($ExchangeServers | Get-PopSettings)
+#This needs to be processed as a foreach to work in PS remoting
+$AllPopSettings = @($ExchangeServers | foreach{Get-PopSettings -Server $_.Identity})
 
 #endregion -Basic Data Collection
 

--- a/Tests/POP003.ps1
+++ b/Tests/POP003.ps1
@@ -1,0 +1,58 @@
+#This is your test
+Function Run-POP003()
+{
+    [CmdletBinding()]
+    param()
+
+    $TestID = "POP003"
+    Write-Verbose "----- Starting test $TestID"
+
+    $PassedList = @()
+    $FailedList = @()
+    $WarningList = @()
+    $InfoList = @()
+    $ErrorList = @()
+
+    #Check POP settings for ProtocolLogEnabled configuration. Protocol logging for POP
+    #does not have age/retention settings, so it can grow to consume all available disk
+    #space on the server. Because external cleanup options are possible, eg running a
+    #script as a scheduled task, if POP protocol logging is enabled it is considered
+    #a warning not a fail.
+
+    foreach ($PopSetting in $AllPopSettings)
+    {
+        Write-Verbose "Checking POP protocol logging settings for $($PopSetting.Server)"
+        
+        switch ($PopSetting.ProtocolLogEnabled -eq $true)
+        {
+            $true {
+                $tmpString = "$($PopSetting.Server) has protocol logging enabled"
+                Write-Verbose $tmpString
+                $WarningList += $PopSetting.Server
+                }
+            $false {
+                $tmpString = "$($PopSetting.Server) has protocol logging disabled"
+                Write-Verbose $tmpString
+                $WarningList += $PopSetting.Server
+                }
+            default {
+                $ErrorList += "$($PopSetting.Server) protocol log setting could not be determined"
+                }
+        }
+    }
+
+    #Roll the object to be returned to the results
+    $ReportObj = Get-TestResultObject -ExchangeAnalyzerTests $ExchangeAnalyzerTests `
+                                      -TestId $TestID `
+                                      -PassedList $PassedList `
+                                      -FailedList $FailedList `
+                                      -WarningList $WarningList `
+                                      -InfoList $InfoList `
+                                      -ErrorList $ErrorList `
+                                      -Verbose:($PSBoundParameters['Verbose'] -eq $true)
+
+    return $ReportObj
+}
+
+Run-POP003
+


### PR DESCRIPTION
This test checks the protocol logging settings for POP services.

If protocol logging is enabled, the test will flag it as a warning. Protocol logging for POP doesn't have retention/age controls that would automatically remove old log files, so they could potentially grow and consume all available disk space. However, admins can implement a script or scheduled task to remove old logs. That would be a separate process, not visible to Exchange, hence the warning.

If protocol logging is disabled, the test passes.