### PR TITLE
Fix issue 78 - Bug with backup timestamp for dismounted DB's or stopped IS

### DIFF
--- a/Tests/DB001.ps1
+++ b/Tests/DB001.ps1
@@ -12,6 +12,8 @@ Function Run-DB001()
 
     $PassedList = @()
     $FailedList = @()
+    $WarningList = @()
+    $InfoList = @()
     $ErrorList = @()
 
     $mailboxdatabases = @($ExchangeDatabases | Where {$_.AdminDisplayVersion -like "Version 15.*" -and $_.Recovery -ne $true})
@@ -109,6 +111,8 @@ Function Run-DB001()
                                       -TestId $TestID `
                                       -PassedList $PassedList `
                                       -FailedList $FailedList `
+                                      -WarningList $WarningList `
+                                      -InfoList $InfoList `
                                       -ErrorList $ErrorList `
                                       -Verbose:($PSBoundParameters['Verbose'] -eq $true)
     return $ReportObj

--- a/Tests/DB001.ps1
+++ b/Tests/DB001.ps1
@@ -28,7 +28,14 @@ Function Run-DB001()
 	        Write-Verbose "Checking $db"
             if ($db.Mounted -eq $false)
             {
-                $tmpString = "$($db.name) is dismounted."
+                $tmpString = "$($db.name) is dismounted"
+                Write-Verbose $tmpString
+                $WarningList += $tmpString
+            }
+            elseif ($db.Mounted -eq $null)
+            {
+                #Indicates Information Store service was stopped on the server
+                $tmpString = "$($db.Name) could not be reached"
                 Write-Verbose $tmpString
                 $WarningList += $tmpString
             }

--- a/Tests/DB001.ps1
+++ b/Tests/DB001.ps1
@@ -86,7 +86,7 @@ Function Run-DB001()
             {
                 $FailedList += "$($db.Name) (Never backed up)"
             }
-            elseif ($($LatestBackup.Value) -gt 24)
+            elseif ($($LatestBackup.Value.ToInt32($null)) -gt 24)
             {
                 $FailedList += "$($db.Name) ($($LatestBackup.Value) hrs ago)"
             }


### PR DESCRIPTION
This fix for issue #78 resolves:

- a bug with the comparison of "hours since last backup" to see if it's greater than 24 (buggy code was comparing a string to an int)
- condition where dismounted databases were reported as "Never" for last backup. Now they report as dismounted.
- condition where a stopped information store service caused all databases on that server to be reported as "Never" for last backup. Now they report as "could not be reached".